### PR TITLE
Update image to RHEL 10.2 (rhel-10-2-eus-06-08-26)

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -1,7 +1,7 @@
 ---
 virtualmachines:
   - name: "rhel"
-    image: "rhel-10-0-07-09-25-3"
+    image: "rhel-10-2-eus-06-08-26"
     bootloader: efi
     memory: "4G"
     cores: 1

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -5,8 +5,8 @@ virtualmachines:
     bootloader: efi
     memory: "4G"
     cores: 1
-    packages:
-      - tmux
+    # packages:
+    # - tmux
     image_size: "40G"
     register_satellite: false
     tags:

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -8,6 +8,7 @@ virtualmachines:
     packages:
       - tmux
     image_size: "40G"
+    register_satellite: false
     tags:
       - key: "AnsibleGroup"
         value: "bastions"

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 #install adminer
+# Unregister and register the VM
+subscription-manager clean
+subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
+
 mkdir /var/www/html/adminer
 wget -O /var/www/html/adminer/index.php https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1-en.php
 

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-#install adminer
 # Unregister and register the VM
 subscription-manager clean
 subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
 
+#install adminer
 mkdir /var/www/html/adminer
 wget -O /var/www/html/adminer/index.php https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1-en.php
 


### PR DESCRIPTION
## Summary
- Updated `instances.yaml` image to `rhel-10-2-eus-06-08-26`
- Disabled satellite registration (`register_satellite: false`)
- Commented out packages block
- Added subscription-manager clean & re-register to `setup-rhel.sh`
- Part of RHEL 10.2 lab migration

## Lab
Intro to Databases